### PR TITLE
Add SIMD support

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -30,7 +30,7 @@ async function configure() {
     `-DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"`,
     `-G Ninja`,
     // emcmake sets a quoted string which then can't be used in cmake COMMAND
-    // See https://github.com/emscripten-core/emscripten/issues/13126
+    // See https://github.com/emscripten-core/emscripten/issues/10028
     `-DCMAKE_CROSSCOMPILING_EMULATOR="${process.execPath}"`,
     '-DJPEGXL_STATIC=ON',
 
@@ -47,7 +47,11 @@ async function configure() {
     `-DJPEGXL_ENABLE_EXAMPLES=OFF`,
     // Enable NODE_CODE_CACHING when it becomes available again.
     // https://github.com/nodejs/node/issues/18265#issuecomment-622990783
-    `-DCMAKE_EXE_LINKER_FLAGS="-s ALLOW_MEMORY_GROWTH=1 -s NODERAWFS=1`,
+    `-DCMAKE_EXE_LINKER_FLAGS="-s ALLOW_MEMORY_GROWTH=1 -s NODERAWFS=1 -msimd128"`,
+    `-DCMAKE_CXX_FLAGS="-msimd128"`,
+    `-DCMAKE_CXX_FLAGS="-msimd128"`,
+    // sjpeg confuses WASM SIMD with SSE
+    `-DSJPEG_ENABLE_SIMD=OFF`,
   ]
   return args.join(" ");
 }


### PR DESCRIPTION
Node.js 15 still requires `--experimental-wasm-simd` for Simd128:

> `RuntimeError: abort(RuntimeError: abort(CompileError: WebAssembly.instantiate(): invalid value type 'Simd128', enable with --experimental-wasm-simd @+342). Build with -s ASSERTIONS=1 for more info.). Build with -s ASSERTIONS=1 for more info.`

This should land only when a new release lands with an official support, with a proper `engines` value in `package.json`.

Closes #3.